### PR TITLE
Username length is 5-32 characters

### DIFF
--- a/include/telebot-common.h
+++ b/include/telebot-common.h
@@ -35,12 +35,12 @@ extern "C" {
  * @addtogroup TELEBOT_API
  * @{
  */
-/** String length limit for firt name */
+/** String length limit for first name */
 #define TELEBOT_FIRST_NAME_SIZE             32
 /** String length limit for last name */
 #define TELEBOT_LAST_NAME_SIZE              32
 /** String length limit for username */
-#define TELEBOT_USER_NAME_SIZE              16
+#define TELEBOT_USER_NAME_SIZE              32
 /** String length for file id */
 #define TELEBOT_FILE_ID_SIZE                256
 /** String length limit for chat type, which is of private, public or group */


### PR DESCRIPTION
Ref.: https://core.telegram.org/bots#botfather

> **Usernames are 5-32 characters long** and are case insensitive, but may only include Latin characters, numbers, and underscores.