### PR TITLE
removed wrong usage of json_object_put

### DIFF
--- a/src/telebot-parser.c
+++ b/src/telebot-parser.c
@@ -75,7 +75,6 @@ telebot_error_e telebot_parser_get_updates(struct json_object *obj,
         struct json_object *update_id;
         if (json_object_object_get_ex(item, "update_id", &update_id)) {
             result[index].update_id = json_object_get_int(update_id);
-            json_object_put(update_id);
         }
 
         struct json_object *message;
@@ -85,7 +84,6 @@ telebot_error_e telebot_parser_get_updates(struct json_object *obj,
                 ERR("Failed to parse message of bot update");
 
             result[index].update_type = UPDATE_TYPE_MESSAGE;
-            json_object_put(message);
         }
 
         struct json_object *callback_query;
@@ -96,10 +94,8 @@ telebot_error_e telebot_parser_get_updates(struct json_object *obj,
                 ERR("Failed to parse callback query of bot update");
 
             result[index].update_type = UPDATE_TYPE_CALLBACK_QUERY;
-            json_object_put(callback_query);
         }
 
-        json_object_put(item);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -118,7 +114,6 @@ telebot_error_e telebot_parser_get_webhook_info(struct json_object *obj,
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
     info->url = strdup_s(json_object_get_string(url));
-    json_object_put(url);
 
     struct json_object *certificate;
     if (!json_object_object_get_ex(obj, "has_custom_certificate", &certificate)) {
@@ -126,7 +121,6 @@ telebot_error_e telebot_parser_get_webhook_info(struct json_object *obj,
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
     info->has_custom_certificate = json_object_get_boolean(certificate);
-    json_object_put(certificate);
 
     struct json_object *update_count;
     if (!json_object_object_get_ex(obj, "pending_update_count", &update_count)) {
@@ -134,12 +128,10 @@ telebot_error_e telebot_parser_get_webhook_info(struct json_object *obj,
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
     info->pending_update_count = json_object_get_int(update_count);
-    json_object_put(update_count);
 
     struct json_object *last_error_date;
     if (json_object_object_get_ex(obj, "last_error_date", &last_error_date)) {
         info->last_error_date = json_object_get_double(last_error_date);
-        json_object_put(last_error_date);
     }
 
     struct json_object *last_error_message;
@@ -150,7 +142,6 @@ telebot_error_e telebot_parser_get_webhook_info(struct json_object *obj,
     struct json_object *max_connections;
     if (json_object_object_get_ex(obj, "max_connections", &max_connections)) {
         info->max_connections = json_object_get_int(max_connections);
-        json_object_put(max_connections);
     }
 
     struct json_object *allowed_updates;
@@ -163,9 +154,7 @@ telebot_error_e telebot_parser_get_webhook_info(struct json_object *obj,
             for (j=0;j<UPDATE_TYPE_MAX;j++)
                 if (strstr(update_type, telebot_update_type_str[j]))
                     info->allowed_updates[cnt++] = j;
-            json_object_put(item);
         }
-        json_object_put(allowed_updates);
         info->allowed_updates_count = cnt;
     } else {
         int i;
@@ -190,7 +179,6 @@ telebot_error_e telebot_parser_get_user(struct json_object *obj,
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
     user->id = json_object_get_int(id);
-    json_object_put(id);
 
     struct json_object *first_name;
     if (!json_object_object_get_ex(obj, "first_name", &first_name)) {
@@ -198,18 +186,15 @@ telebot_error_e telebot_parser_get_user(struct json_object *obj,
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
     user->first_name = strdup_s(json_object_get_string(first_name));
-    json_object_put(first_name);
 
     struct json_object *last_name;
     if (json_object_object_get_ex(obj, "last_name", &last_name)) {
         user->last_name = strdup_s(json_object_get_string(last_name));
-        json_object_put(last_name);
     }
 
     struct json_object *username;
     if (json_object_object_get_ex(obj, "username", &username)) {
         user->username = strdup_s(json_object_get_string(username));
-        json_object_put(username);
     }
 
     struct json_object *language_code;
@@ -240,7 +225,6 @@ static telebot_error_e telebot_parser_get_users(struct json_object *obj,
         struct json_object *item = json_object_array_get_idx(array, index);
         if (telebot_parser_get_user(item, &(result[index])) != TELEBOT_ERROR_NONE)
             ERR("Failed to parse user from users array");
-        json_object_put(item);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -257,7 +241,6 @@ telebot_error_e telebot_parser_get_chat(struct json_object *obj,
     struct json_object *id;
     if (json_object_object_get_ex(obj, "id", &id)) {
         chat->id = json_object_get_int(id);
-        json_object_put(id);
     }
     else {
         ERR("Object is not chat type, id not found");
@@ -267,7 +250,6 @@ telebot_error_e telebot_parser_get_chat(struct json_object *obj,
     struct json_object *type;
     if (json_object_object_get_ex(obj, "type", &type)){
         chat->type = strdup_s(json_object_get_string(type));
-        json_object_put(type);
     }
     else {
         ERR("Object is not chat type, type not found");
@@ -277,25 +259,21 @@ telebot_error_e telebot_parser_get_chat(struct json_object *obj,
     struct json_object *title;
     if (json_object_object_get_ex(obj, "title", &title)) {
         chat->title = strdup_s(json_object_get_string(title));
-        json_object_put(title);
     }
 
     struct json_object *username;
     if (json_object_object_get_ex(obj, "username", &username)) {
         chat->username = strdup_s(json_object_get_string(username));
-        json_object_put(username);
     }
 
     struct json_object *first_name;
     if (json_object_object_get_ex(obj, "first_name", &first_name)) {
         chat->first_name = strdup_s(json_object_get_string(first_name));
-        json_object_put(first_name);
     }
 
     struct json_object *last_name;
     if (json_object_object_get_ex(obj, "last_name", &last_name)) {
         chat->last_name = strdup_s(json_object_get_string(last_name));
-        json_object_put(last_name);
     }
 
     struct json_object *chat_photo;
@@ -307,19 +285,16 @@ telebot_error_e telebot_parser_get_chat(struct json_object *obj,
             free(chat->photo);
             chat->photo = NULL;
         }
-        json_object_put(chat_photo);
     }
 
     struct json_object *description;
     if (json_object_object_get_ex(obj, "description", &description)) {
         chat->description = strdup_s(json_object_get_string(description));
-        json_object_put(description);
     }
 
     struct json_object *invite_link;
     if (json_object_object_get_ex(obj, "invite_link", &invite_link)) {
         chat->invite_link = strdup_s(json_object_get_string(invite_link));
-        json_object_put(invite_link);
     }
 
     struct json_object *pinned_message;
@@ -331,19 +306,16 @@ telebot_error_e telebot_parser_get_chat(struct json_object *obj,
             free(chat->pinned_message);
             chat->pinned_message = NULL;
         }
-        json_object_put(pinned_message);
     }
 
     struct json_object *sticker_set_name;
     if (json_object_object_get_ex(obj, "sticker_set_name", &sticker_set_name)) {
         chat->sticker_set_name = strdup_s(json_object_get_string(sticker_set_name));
-        json_object_put(sticker_set_name);
     }
 
     struct json_object *can_set_sticker_set;
     if (json_object_object_get_ex(obj, "can_set_sticker_set", &can_set_sticker_set)) {
         chat->can_set_sticker_set = json_object_get_boolean(can_set_sticker_set);
-        json_object_put(can_set_sticker_set);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -363,7 +335,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
     msg->message_id = json_object_get_int(message_id);
-    json_object_put(message_id);
 
     struct json_object *from;
     if (json_object_object_get_ex(obj, "from", &from)) {
@@ -374,13 +345,11 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->from);
             msg->from = NULL;
         }
-        json_object_put(from);
     }
 
     struct json_object *date;
     if (json_object_object_get_ex(obj, "date", &date)) {
         msg->date = json_object_get_int(date);
-        json_object_put(date);
     }
 
     struct json_object *chat;
@@ -392,7 +361,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->chat);
             msg->chat = NULL;
         }
-        json_object_put(chat);
     }
 
     struct json_object *forward_from;
@@ -404,13 +372,11 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->forward_from);
             msg->forward_from = NULL;
         }
-        json_object_put(forward_from);
     }
 
     struct json_object *forward_date;
     if (json_object_object_get_ex(obj, "forward_date", &forward_date)) {
         msg->forward_date = json_object_get_int(forward_date);
-        json_object_put(forward_date);
     }
 
     struct json_object *reply_to_message;
@@ -422,31 +388,26 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->reply_to_message);
             msg->reply_to_message = NULL;
         }
-        json_object_put(reply_to_message);
     }
 
     struct json_object *edit_date;
     if (json_object_object_get_ex(obj, "edit_date", &edit_date)) {
         msg->edit_date = json_object_get_int(edit_date);
-        json_object_put(edit_date);
     }
 
     struct json_object *media_group_id;
     if (json_object_object_get_ex(obj, "media_group_id", &media_group_id)) {
         msg->media_group_id = strdup_s(json_object_get_string(media_group_id));
-        json_object_put(media_group_id);
     }
 
     struct json_object *author_signature;
     if (json_object_object_get_ex(obj, "author_signature", &author_signature)) {
         msg->author_signature = strdup_s(json_object_get_string(author_signature));
-        json_object_put(author_signature);
     }
 
     struct json_object *text;
     if (json_object_object_get_ex(obj, "text", &text)) {
         msg->text = strdup_s(json_object_get_string(text));
-        json_object_put(text);
     }
 
     struct json_object *entities;
@@ -455,7 +416,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
                 &(msg->count_entities));
         if (ret != TELEBOT_ERROR_NONE)
             ERR("Failed to get <entities> from message object");
-        json_object_put(entities);
     }
 
     struct json_object *caption_entities;
@@ -464,7 +424,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
                 &(msg->caption_entities), &(msg->count_caption_entities));
         if (ret != TELEBOT_ERROR_NONE)
             ERR("Failed to get <caption_entities> from message object");
-        json_object_put(caption_entities);
     }
 
     struct json_object *audio;
@@ -476,7 +435,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->audio);
             msg->audio = NULL;
         }
-        json_object_put(audio);
     }
 
     struct json_object *document;
@@ -488,7 +446,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->document);
             msg->document = NULL;
         }
-        json_object_put(document);
     }
 
     //TODO: implement game parsing
@@ -499,7 +456,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
                 &(msg->count_photos));
         if (ret != TELEBOT_ERROR_NONE)
             ERR("Failed to get <photo> from message object");
-        json_object_put(photo);
     }
 
     struct json_object *sticker;
@@ -511,7 +467,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->sticker);
             msg->sticker = NULL;
         }
-        json_object_put(sticker);
     }
 
     struct json_object *video;
@@ -523,7 +478,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->video);
             msg->video = NULL;
         }
-        json_object_put(video);
     }
 
     struct json_object *video_note;
@@ -535,7 +489,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->video_note);
             msg->video_note = NULL;
         }
-        json_object_put(video_note);
     }
 
     struct json_object *voice;
@@ -547,13 +500,11 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->voice);
             msg->voice = NULL;
         }
-        json_object_put(voice);
     }
 
     struct json_object *caption;
     if (json_object_object_get_ex(obj, "caption", &caption)) {
         msg->new_chat_title = strdup_s(json_object_get_string(caption));
-        json_object_put(caption);
     }
 
     struct json_object *contact;
@@ -565,7 +516,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->contact);
             msg->contact = NULL;
         }
-        json_object_put(contact);
     }
 
     struct json_object *location;
@@ -577,7 +527,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->location);
             msg->location = NULL;
         }
-        json_object_put(location);
     }
 
     struct json_object *venue;
@@ -589,7 +538,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->venue);
             msg->venue = NULL;
         }
-        json_object_put(venue);
     }
 
     struct json_object *ncm;
@@ -598,7 +546,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
                 &(msg->count_new_chat_members));
         if (ret != TELEBOT_ERROR_NONE)
             ERR("Failed to get <new_chat_members> from message object");
-        json_object_put(ncm);
     }
 
     struct json_object *lcm;
@@ -607,13 +554,11 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
                 &(msg->count_left_chat_members));
         if (ret != TELEBOT_ERROR_NONE)
             ERR("Failed to get <left_chat_members> from message object");
-        json_object_put(lcm);
     }
 
     struct json_object *nct;
     if (json_object_object_get_ex(obj, "new_chat_title", &nct)) {
         msg->new_chat_title = strdup_s(json_object_get_string(nct));
-        json_object_put(nct);
     }
 
     struct json_object *new_chat_photo;
@@ -622,43 +567,36 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
                 &(msg->count_new_chat_photos));
         if (ret != TELEBOT_ERROR_NONE)
             ERR("Failed to get <new_chat_photo> from message object");
-        json_object_put(new_chat_photo);
     }
 
     struct json_object *del_chat_photo;
     if (json_object_object_get_ex(obj, "delete_chat_photo", &del_chat_photo)) {
         msg->delete_chat_photo = json_object_get_boolean(del_chat_photo);
-        json_object_put(del_chat_photo);
     }
 
     struct json_object *gcc;
     if (json_object_object_get_ex(obj, "group_chat_created", &gcc)) {
         msg->group_chat_created = json_object_get_boolean(gcc);
-        json_object_put(gcc);
     }
 
     struct json_object *sgcc;
     if (json_object_object_get_ex(obj, "supergroup_chat_created", &sgcc)) {
         msg->supergroup_chat_created = json_object_get_boolean(sgcc);
-        json_object_put(sgcc);
     }
 
     struct json_object *cacc;
     if (json_object_object_get_ex(obj, "channel_chat_created", &cacc)) {
         msg->channel_chat_created = json_object_get_boolean(cacc);
-        json_object_put(cacc);
     }
 
     struct json_object *mtci;
     if (json_object_object_get_ex(obj, "migrate_to_chat_id", &mtci)) {
         msg->migrate_to_chat_id = json_object_get_int(mtci);
-        json_object_put(mtci);
     }
 
     struct json_object *mftci;
     if (json_object_object_get_ex(obj, "migrate_from_chat_id", &mftci)) {
         msg->migrate_from_chat_id = json_object_get_int(mftci);
-        json_object_put(mftci);
     }
 
     struct json_object *pinned_message;
@@ -670,7 +608,6 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
             free(msg->pinned_message);
             msg->pinned_message = NULL;
         }
-        json_object_put(pinned_message);
     }
 
     //TODO: implement invoce & successful_payment
@@ -688,7 +625,6 @@ telebot_error_e telebot_parser_get_message_entity(struct json_object *obj,
     struct json_object *type;
     if (json_object_object_get_ex(obj, "type", &type)) {
         entity->type = strdup_s(json_object_get_string(type));
-        json_object_put(type);
     }
     else {
         ERR("Object is not message entity type, type not found");
@@ -698,7 +634,6 @@ telebot_error_e telebot_parser_get_message_entity(struct json_object *obj,
     struct json_object *offset;
     if (json_object_object_get_ex(obj, "offset", &offset)){
         entity->offset = json_object_get_int(offset);
-        json_object_put(offset);
     }
     else {
         free(entity->type);
@@ -710,7 +645,6 @@ telebot_error_e telebot_parser_get_message_entity(struct json_object *obj,
     struct json_object *length;
     if (json_object_object_get_ex(obj, "length", &length)){
         entity->length = json_object_get_int(length);
-        json_object_put(length);
     }
     else {
         ERR("Object is not message entity type, length not found");
@@ -723,7 +657,6 @@ telebot_error_e telebot_parser_get_message_entity(struct json_object *obj,
     struct json_object *url;
     if (json_object_object_get_ex(obj, "url", &url)) {
         entity->url = strdup_s(json_object_get_string(url));
-        json_object_put(url);
     }
 
     struct json_object *user;
@@ -735,7 +668,6 @@ telebot_error_e telebot_parser_get_message_entity(struct json_object *obj,
             free(entity->user);
             entity->user = NULL;
         }
-        json_object_put(user);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -762,7 +694,6 @@ telebot_error_e telebot_parser_get_message_entities(struct json_object *obj,
         ret = telebot_parser_get_message_entity(item, &(result[index]));
         if (ret != TELEBOT_ERROR_NONE)
             ERR("Failed to parse user from users array");
-        json_object_put(item);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -779,7 +710,6 @@ telebot_error_e telebot_parser_get_photo(struct json_object *obj,
     struct json_object *file_id;
     if (json_object_object_get_ex(obj, "file_id", &file_id)) {
         photo->file_id = strdup_s(json_object_get_string(file_id));
-        json_object_put(file_id);
     }
     else {
         ERR("Object is not photo size type, file_id not found");
@@ -789,7 +719,6 @@ telebot_error_e telebot_parser_get_photo(struct json_object *obj,
     struct json_object *width;
     if (json_object_object_get_ex(obj, "width", &width)){
         photo->width = json_object_get_int(width);
-        json_object_put(width);
     }
     else {
         ERR("Object is not photo size type, width not found");
@@ -801,7 +730,6 @@ telebot_error_e telebot_parser_get_photo(struct json_object *obj,
     struct json_object *height;
     if (json_object_object_get_ex(obj, "height", &height)){
         photo->height = json_object_get_int(height);
-        json_object_put(height);
     }
     else {
         ERR("Object is not photo size type, height not found");
@@ -814,7 +742,6 @@ telebot_error_e telebot_parser_get_photo(struct json_object *obj,
     struct json_object *file_size;
     if (json_object_object_get_ex(obj, "file_size", &file_size)) {
         photo->file_size = json_object_get_int(file_size);
-        json_object_put(file_size);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -841,7 +768,6 @@ static telebot_error_e telebot_parser_get_photos(struct json_object *obj,
         ret = telebot_parser_get_photo(item, &(result[index]));
         if (ret != TELEBOT_ERROR_NONE)
             ERR("Failed to parse user from users array");
-        json_object_put(item);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -858,7 +784,6 @@ telebot_error_e telebot_parser_get_audio(struct json_object *obj,
     struct json_object *file_id;
     if (json_object_object_get_ex(obj, "file_id", &file_id)) {
         audio->file_id = strdup_s(json_object_get_string(file_id));
-        json_object_put(file_id);
     }
     else {
         ERR("Object is not audio type, file_id not found");
@@ -868,7 +793,6 @@ telebot_error_e telebot_parser_get_audio(struct json_object *obj,
     struct json_object *duration;
     if (json_object_object_get_ex(obj, "duration", &duration)){
         audio->duration = json_object_get_int(duration);
-        json_object_put(duration);
     }
     else {
         ERR("Object is not audio type, duration not found");
@@ -880,25 +804,21 @@ telebot_error_e telebot_parser_get_audio(struct json_object *obj,
     struct json_object *performer;
     if (json_object_object_get_ex(obj, "performer", &performer)) {
         audio->performer = strdup_s(json_object_get_string(performer));
-        json_object_put(performer);
     }
 
     struct json_object *title;
     if (json_object_object_get_ex(obj, "title", &title)) {
         audio->title = strdup_s(json_object_get_string(title));
-        json_object_put(title);
     }
 
     struct json_object *mime_type;
     if (json_object_object_get_ex(obj, "mime_type", &mime_type)) {
         audio->mime_type = strdup_s(json_object_get_string(mime_type));
-        json_object_put(mime_type);
     }
 
     struct json_object *file_size;
     if (json_object_object_get_ex(obj, "file_size", &file_size)) {
         audio->file_size = json_object_get_int(file_size);
-        json_object_put(file_size);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -914,7 +834,6 @@ telebot_error_e telebot_parser_get_document(struct json_object *obj,
     struct json_object *file_id;
     if (json_object_object_get_ex(obj, "file_id", &file_id)) {
         document->file_id = strdup_s(json_object_get_string(file_id));
-        json_object_put(file_id);
     }
     else {
         ERR("Object is not audio type, file_id not found");
@@ -930,25 +849,21 @@ telebot_error_e telebot_parser_get_document(struct json_object *obj,
             free(document->thumb);
             document->thumb = NULL;
         }
-        json_object_put(thumb);
     }
 
     struct json_object *file_name;
     if (json_object_object_get_ex(obj, "file_name", &file_name)) {
         document->file_name = strdup_s(json_object_get_string(file_name));
-        json_object_put(file_name);
     }
 
     struct json_object *mime_type;
     if (json_object_object_get_ex(obj, "mime_type", &mime_type)) {
         document->mime_type = strdup_s(json_object_get_string(mime_type));
-        json_object_put(file_name);
     }
 
     struct json_object *file_size;
     if (json_object_object_get_ex(obj, "file_size", &file_size)) {
         document->file_size = json_object_get_int(file_size);
-        json_object_put(file_name);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -964,7 +879,6 @@ telebot_error_e telebot_parser_get_video(struct json_object *obj,
     struct json_object *file_id;
     if (json_object_object_get_ex(obj, "file_id", &file_id)) {
         video->file_id = strdup_s(json_object_get_string(file_id));
-        json_object_put(file_id);
     }
     else {
         ERR("Object is not video type, file_id not found");
@@ -974,7 +888,6 @@ telebot_error_e telebot_parser_get_video(struct json_object *obj,
     struct json_object *width;
     if (json_object_object_get_ex(obj, "width", &width)){
         video->width = json_object_get_int(width);
-        json_object_put(width);
     }
     else {
         ERR("Object is not video type, width not found");
@@ -986,7 +899,6 @@ telebot_error_e telebot_parser_get_video(struct json_object *obj,
     struct json_object *height;
     if (json_object_object_get_ex(obj, "height", &height)){
         video->height = json_object_get_int(height);
-        json_object_put(height);
     }
     else {
         ERR("Object is not video type, height not found");
@@ -999,7 +911,6 @@ telebot_error_e telebot_parser_get_video(struct json_object *obj,
     struct json_object *duration;
     if (json_object_object_get_ex(obj, "duration", &duration)){
         video->duration = json_object_get_int(duration);
-        json_object_put(duration);
     }
     else {
         ERR("Object is not video type, duration not found");
@@ -1019,19 +930,16 @@ telebot_error_e telebot_parser_get_video(struct json_object *obj,
             free(video->thumb);
             video->thumb = NULL;
         }
-        json_object_put(thumb);
     }
 
     struct json_object *mime_type;
     if (json_object_object_get_ex(obj, "mime_type", &mime_type)) {
         video->mime_type = strdup_s(json_object_get_string(mime_type));
-        json_object_put(mime_type);
     }
 
     struct json_object *file_size;
     if (json_object_object_get_ex(obj, "file_size", &file_size)) {
         video->file_size = json_object_get_int(file_size);
-        json_object_put(file_size);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -1047,7 +955,6 @@ telebot_error_e telebot_parser_get_video_note(struct json_object *obj,
     struct json_object *file_id;
     if (json_object_object_get_ex(obj, "file_id", &file_id)) {
         video_note->file_id = strdup_s(json_object_get_string(file_id));
-        json_object_put(file_id);
     }
     else {
         ERR("Object is not video note type, file_id not found");
@@ -1057,7 +964,6 @@ telebot_error_e telebot_parser_get_video_note(struct json_object *obj,
     struct json_object *length;
     if (json_object_object_get_ex(obj, "length", &length)){
         video_note->length = json_object_get_int(length);
-        json_object_put(length);
     }
     else {
         ERR("Object is not video note type, length not found");
@@ -1069,7 +975,6 @@ telebot_error_e telebot_parser_get_video_note(struct json_object *obj,
     struct json_object *duration;
     if (json_object_object_get_ex(obj, "duration", &duration)){
         video_note->duration = json_object_get_int(duration);
-        json_object_put(duration);
     }
     else {
         ERR("Object is not video note type, duration not found");
@@ -1088,13 +993,11 @@ telebot_error_e telebot_parser_get_video_note(struct json_object *obj,
             free(video_note->thumb);
             video_note->thumb = NULL;
         }
-        json_object_put(thumb);
     }
 
     struct json_object *file_size;
     if (json_object_object_get_ex(obj, "file_size", &file_size)) {
         video_note->file_size = json_object_get_int(file_size);
-        json_object_put(file_size);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -1110,7 +1013,6 @@ telebot_error_e telebot_parser_get_voice(struct json_object *obj,
     struct json_object *file_id;
     if (json_object_object_get_ex(obj, "file_id", &file_id)) {
         voice->file_id = strdup_s(json_object_get_string(file_id));
-        json_object_put(file_id);
     }
     else {
         ERR("Object is not voice type, file_id not found");
@@ -1120,7 +1022,6 @@ telebot_error_e telebot_parser_get_voice(struct json_object *obj,
     struct json_object *duration;
     if (json_object_object_get_ex(obj, "duration", &duration)){
         voice->duration = json_object_get_int(duration);
-        json_object_put(duration);
     }
     else {
         ERR("Object is not voice type, voice duration not found");
@@ -1132,13 +1033,11 @@ telebot_error_e telebot_parser_get_voice(struct json_object *obj,
     struct json_object *mime_type;
     if (json_object_object_get_ex(obj, "mime_type", &mime_type)) {
         voice->mime_type = strdup_s(json_object_get_string(mime_type));
-        json_object_put(mime_type);
     }
 
     struct json_object *file_size;
     if (json_object_object_get_ex(obj, "file_size", &file_size)) {
         voice->file_size = json_object_get_int(file_size);
-        json_object_put(file_size);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -1154,7 +1053,6 @@ telebot_error_e telebot_parser_get_contact(struct json_object *obj,
     struct json_object *phone_number;
     if (json_object_object_get_ex(obj, "phone_number", &phone_number)) {
         contact->phone_number = strdup_s(json_object_get_string(phone_number));
-        json_object_put(phone_number);
     }
     else {
         ERR("Object is not contact type, phone number not found");
@@ -1164,7 +1062,6 @@ telebot_error_e telebot_parser_get_contact(struct json_object *obj,
     struct json_object *first_name;
     if (json_object_object_get_ex(obj, "first_name", &first_name)){
         contact->first_name = strdup_s(json_object_get_string(first_name));
-        json_object_put(first_name);
     }
     else {
         ERR("Object is not contact type, first name not found");
@@ -1176,13 +1073,11 @@ telebot_error_e telebot_parser_get_contact(struct json_object *obj,
     struct json_object *last_name;
     if (json_object_object_get_ex(obj, "last_name", &last_name)){
         contact->last_name = strdup_s(json_object_get_string(last_name));
-        json_object_put(last_name);
     }
 
     struct json_object *user_id;
     if (json_object_object_get_ex(obj, "user_id", &user_id)) {
         contact->user_id = json_object_get_int(user_id);
-        json_object_put(user_id);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -1198,7 +1093,6 @@ telebot_error_e telebot_parser_get_location(struct json_object *obj,
     struct json_object *latitude;
     if (json_object_object_get_ex(obj, "latitude", &latitude)) {
         location->latitude = json_object_get_double(latitude);
-        json_object_put (latitude);
     }
     else {
         ERR("Object is not location type, latitude not found");
@@ -1208,7 +1102,6 @@ telebot_error_e telebot_parser_get_location(struct json_object *obj,
     struct json_object *longitude;
     if (json_object_object_get_ex(obj, "longitude", &longitude)) {
         location->longitude = json_object_get_double(longitude);
-        json_object_put (longitude);
     }
     else {
         ERR("Object is not location type, longitude not found");
@@ -1228,7 +1121,6 @@ telebot_error_e telebot_parser_get_venue(struct json_object *obj,
     struct json_object *title;
     if (json_object_object_get_ex(obj, "title", &title)) {
         venue->title = strdup_s(json_object_get_string(title));
-        json_object_put(title);
     }
     else {
         ERR("Object is not venue type, title not found");
@@ -1238,7 +1130,6 @@ telebot_error_e telebot_parser_get_venue(struct json_object *obj,
     struct json_object *address;
     if (json_object_object_get_ex(obj, "address", &address)) {
         venue->address = strdup_s(json_object_get_string(address));
-        json_object_put(address);
     }
     else {
         ERR("Object is not venue type, address not found");
@@ -1259,10 +1150,8 @@ telebot_error_e telebot_parser_get_venue(struct json_object *obj,
             venue->title = NULL;
             free(venue->address);
             venue->address = NULL;
-            json_object_put(location);
             return TELEBOT_ERROR_OPERATION_FAILED;
         }
-        json_object_put(location);
     }
     else {
         ERR("Object is not venue type, location not found");
@@ -1276,7 +1165,6 @@ telebot_error_e telebot_parser_get_venue(struct json_object *obj,
     struct json_object *foursquare_id;
     if (json_object_object_get_ex(obj, "foursquare_id", &foursquare_id)) {
         venue->foursquare_id = strdup_s(json_object_get_string(foursquare_id));
-        json_object_put(foursquare_id);
     }
 
     return TELEBOT_ERROR_NONE;
@@ -1293,7 +1181,6 @@ telebot_error_e telebot_parser_get_user_profile_photos(struct json_object *obj,
     struct json_object *total_count_obj;
     if (json_object_object_get_ex(obj, "total_count", &total_count_obj)) {
         total_count = json_object_get_int(total_count_obj);
-        json_object_put(total_count_obj);
     }
     else {
         ERR("Object is not user profile photo type, total_count not found");
@@ -1323,11 +1210,8 @@ telebot_error_e telebot_parser_get_user_profile_photos(struct json_object *obj,
         for(j=0;j<subtotal;j++) {
             struct json_object *photo = json_object_array_get_idx(item, j);
             ret |= telebot_parser_get_photo(photo, &(photos->photos[j][i]));
-            json_object_put(photo);
         }
-        json_object_put(item);
     }
-    json_object_put(array);
 
     if (ret != TELEBOT_ERROR_NONE) {
         for (i=0;i<4;i++) {
@@ -1350,7 +1234,6 @@ telebot_error_e telebot_parser_get_file_path(struct json_object *obj,
     struct json_object *file_path;
     if (json_object_object_get_ex(obj, "file_path", &file_path)) {
         *path = strdup_s(json_object_get_string(file_path));
-        json_object_put(file_path);
     }
     else {
         *path = NULL;
@@ -1371,7 +1254,6 @@ telebot_error_e  telebot_parser_get_chat_photo(struct json_object *obj,
     struct json_object *small_file_id;
     if (json_object_object_get_ex(obj, "small_file_id", &small_file_id)) {
         photo->small_file_id = strdup_s(json_object_get_string(small_file_id));
-        json_object_put(small_file_id);
     }
     else {
         ERR("Object is not chat photo type, small_file_id not found");
@@ -1381,7 +1263,6 @@ telebot_error_e  telebot_parser_get_chat_photo(struct json_object *obj,
     struct json_object *big_file_id;
     if (json_object_object_get_ex(obj, "big_file_id", &big_file_id)) {
         photo->big_file_id = strdup_s(json_object_get_string(big_file_id));
-        json_object_put(big_file_id);
     }
     else {
         ERR("Object is not chat photo type, big_file_id not found");
@@ -1402,7 +1283,6 @@ telebot_error_e telebot_parser_get_sticker(struct json_object *obj,
     struct json_object *file_id;
     if (json_object_object_get_ex(obj, "file_id", &file_id)) {
         sticker->file_id = strdup_s(json_object_get_string(file_id));
-        json_object_put(file_id);
     }
     else {
         ERR("Object is not sticker type, file_id not found");
@@ -1412,7 +1292,6 @@ telebot_error_e telebot_parser_get_sticker(struct json_object *obj,
     struct json_object *width;
     if (json_object_object_get_ex(obj, "width", &width)){
         sticker->width = json_object_get_int(width);
-        json_object_put(width);
     }
     else {
         ERR("Object is not sticker type, width not found");
@@ -1422,7 +1301,6 @@ telebot_error_e telebot_parser_get_sticker(struct json_object *obj,
     struct json_object *height;
     if (json_object_object_get_ex(obj, "height", &height)){
         sticker->height = json_object_get_int(height);
-        json_object_put(height);
     }
     else {
         ERR("Object is not sticker type, height not found");
@@ -1438,19 +1316,16 @@ telebot_error_e telebot_parser_get_sticker(struct json_object *obj,
             free(sticker->thumb);
             sticker->thumb = NULL;
         }
-        json_object_put(thumb);
     }
 
     struct json_object *emoji;
     if (json_object_object_get_ex(obj, "emoji", &emoji)) {
         sticker->emoji = strdup_s(json_object_get_string(emoji));
-        json_object_put(emoji);
     }
 
     struct json_object *set_name;
     if (json_object_object_get_ex(obj, "set_name", &set_name)) {
         sticker->set_name = strdup_s(json_object_get_string(set_name));
-        json_object_put(set_name);
     }
 
     struct json_object *mask_position;
@@ -1462,13 +1337,11 @@ telebot_error_e telebot_parser_get_sticker(struct json_object *obj,
             free(sticker->mask_position);
             sticker->mask_position = NULL;
         }
-        json_object_put(mask_position);
     }
 
     struct json_object *file_size;
     if (json_object_object_get_ex(obj, "file_size", &file_size)) {
         sticker->file_size = json_object_get_int(file_size);
-        json_object_put(file_size);
     }
     return TELEBOT_ERROR_NONE;
 }
@@ -1482,7 +1355,6 @@ telebot_error_e telebot_parser_get_mask_position(struct json_object *obj,
     struct json_object *point;
     if (json_object_object_get_ex(obj, "point", &point)) {
         mask_position->point = strdup_s(json_object_get_string(point));
-        json_object_put(point);
     }
     else {
         ERR("Object is not mask_position type, point not found");
@@ -1492,7 +1364,6 @@ telebot_error_e telebot_parser_get_mask_position(struct json_object *obj,
     struct json_object *x_shift;
     if (json_object_object_get_ex(obj, "x_shift", &x_shift)){
         mask_position->x_shift = json_object_get_double(x_shift);
-        json_object_put(x_shift);
     }
     else {
         ERR("Object is not mask_position type, x_shift not found");
@@ -1502,7 +1373,6 @@ telebot_error_e telebot_parser_get_mask_position(struct json_object *obj,
     struct json_object *y_shift;
     if (json_object_object_get_ex(obj, "y_shift", &y_shift)){
         mask_position->y_shift = json_object_get_double(y_shift);
-        json_object_put(y_shift);
     }
     else {
         ERR("Object is not mask_position type, y_shift not found");
@@ -1512,7 +1382,6 @@ telebot_error_e telebot_parser_get_mask_position(struct json_object *obj,
     struct json_object *scale;
     if (json_object_object_get_ex(obj, "scale", &scale)){
         mask_position->scale = json_object_get_double(scale);
-        json_object_put(scale);
     }
     else {
         ERR("Object is not mask_position type, scale not found");
@@ -1542,7 +1411,6 @@ telebot_error_e telebot_parser_get_callback_query(struct json_object *obj,
     }
 
     cb_query->id = strdup_s(json_object_get_string(id));
-    json_object_put(id);
 
 
     struct json_object *from;
@@ -1551,7 +1419,6 @@ telebot_error_e telebot_parser_get_callback_query(struct json_object *obj,
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
     ret = telebot_parser_get_user(from , &(cb_query->from));
-    json_object_put(from);
 
     if (ret != TELEBOT_ERROR_NONE) {
         ERR("Failed to get <from> from callback_query object");
@@ -1564,7 +1431,6 @@ telebot_error_e telebot_parser_get_callback_query(struct json_object *obj,
         if (ret != TELEBOT_ERROR_NONE) {
             ERR("Failed to get <message> from callback_query object");
         }
-        json_object_put(message);
     }
 
 
@@ -1579,7 +1445,6 @@ telebot_error_e telebot_parser_get_callback_query(struct json_object *obj,
         const char* tmp_inline_message_id = json_object_get_string(inline_message_id);
         strncpy(cb_query->inline_message_id, tmp_inline_message_id,
                 inline_message_id_len + 1);
-        json_object_put(inline_message_id);
     }
 
 
@@ -1593,7 +1458,6 @@ telebot_error_e telebot_parser_get_callback_query(struct json_object *obj,
 
         const char* tmp_chat_instance = json_object_get_string(chat_instance);
         strncpy(cb_query->chat_instance, tmp_chat_instance, chat_instance_len + 1);
-        json_object_put(chat_instance);
     }
 
 
@@ -1607,7 +1471,6 @@ telebot_error_e telebot_parser_get_callback_query(struct json_object *obj,
 
         const char* tmp_data = json_object_get_string(data);
         strncpy(cb_query->data, tmp_data, data_len + 1);
-        json_object_put(data);
     }
 
 
@@ -1621,7 +1484,6 @@ telebot_error_e telebot_parser_get_callback_query(struct json_object *obj,
 
         const char* tmp_game_short_name = json_object_get_string(game_short_name);
         strncpy(cb_query->game_short_name, tmp_game_short_name, game_short_name_len + 1);
-        json_object_put(game_short_name);
     }
 #endif
 

--- a/src/telebot.c
+++ b/src/telebot.c
@@ -171,11 +171,9 @@ telebot_error_e telebot_get_updates(telebot_handler_t handle, int offset,
     }
 
     if (!json_object_get_boolean(ok)) {
-        json_object_put(ok);
         json_object_put(obj);
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
-    json_object_put(ok);
 
     struct json_object *result;
     if (!json_object_object_get_ex(obj, "result", &result)) {
@@ -184,7 +182,6 @@ telebot_error_e telebot_get_updates(telebot_handler_t handle, int offset,
     }
 
     ret = telebot_parser_get_updates(result, updates, count);
-    json_object_put(result);
     json_object_put(obj);
 
     if (ret != TELEBOT_ERROR_NONE)
@@ -260,12 +257,10 @@ telebot_error_e telebot_get_me(telebot_handler_t handle, telebot_user_t **me)
     }
 
     if (!json_object_get_boolean(ok)) {
-        json_object_put(ok);
         json_object_put(obj);
         tb_sfree(*me);
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
-    json_object_put(ok);
 
     struct json_object *result;
     if (!json_object_object_get_ex(obj, "result", &result)){
@@ -275,7 +270,6 @@ telebot_error_e telebot_get_me(telebot_handler_t handle, telebot_user_t **me)
     }
 
     ret = telebot_parser_get_user(result, *me);
-    json_object_put(result);
     json_object_put(obj);
 
     if (ret != TELEBOT_ERROR_NONE) {
@@ -378,12 +372,10 @@ telebot_error_e telebot_get_webhook_info(telebot_handler_t handle,
     }
 
     if (!json_object_get_boolean(ok)) {
-        json_object_put(ok);
         json_object_put(obj);
         tb_sfree(*info);
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
-    json_object_put(ok);
 
     struct json_object *result;
     if (!json_object_object_get_ex(obj, "result", &result)){
@@ -393,7 +385,6 @@ telebot_error_e telebot_get_webhook_info(telebot_handler_t handle,
     }
 
     ret = telebot_parser_get_webhook_info(result, *info);
-    json_object_put(result);
     json_object_put(obj);
 
     if (ret != TELEBOT_ERROR_NONE) {
@@ -669,12 +660,10 @@ telebot_error_e telebot_get_user_profile_photos(telebot_handler_t handle,
     }
 
     if (!json_object_get_boolean(ok)) {
-        json_object_put(ok);
         json_object_put(obj);
         tb_sfree(*photos);
         return TELEBOT_ERROR_OPERATION_FAILED;
     }
-    json_object_put(ok);
 
     struct json_object *result;
     if (!json_object_object_get_ex(obj, "result", &result)) {
@@ -684,7 +673,6 @@ telebot_error_e telebot_get_user_profile_photos(telebot_handler_t handle,
     }
 
     ret = telebot_parser_get_user_profile_photos(result, *photos);
-    json_object_put(result);
     json_object_put(obj);
 
     if (ret != TELEBOT_ERROR_NONE) {


### PR DESCRIPTION
There is no need call json_object_put for children objects if its called for parent object.
Moreover this is cause application failure because of double free memory.