### PR TITLE
Bot is usable in groups now

### DIFF
--- a/include/telebot-core.h
+++ b/include/telebot-core.h
@@ -165,7 +165,7 @@ telebot_error_e telebot_core_get_me(telebot_core_handler_t *core_h);
  * error value. Response is placed in core_h->resp_data. It MUST be freed.
  */
 telebot_error_e telebot_core_send_message(telebot_core_handler_t *core_h,
-        int chat_id, char *text, char *parse_mode, bool disable_web_page_preview,
+        long long int chat_id, char *text, char *parse_mode, bool disable_web_page_preview,
         bool disable_notification, int reply_to_message_id, const char *reply_markup);
 
 /**
@@ -183,7 +183,7 @@ telebot_error_e telebot_core_send_message(telebot_core_handler_t *core_h,
  * message. It MUST be freed.
  */
 telebot_error_e telebot_core_forward_message(telebot_core_handler_t *core_h,
-        int chat_id, int from_chat_id, bool disable_notification, int message_id);
+        long long int chat_id, long long int from_chat_id, bool disable_notification, int message_id);
 
 /**
  * @brief This functionis used to send photos.
@@ -204,7 +204,7 @@ telebot_error_e telebot_core_forward_message(telebot_core_handler_t *core_h,
  * error value. Response is placed in core_h->resp_data that contains the sent
  * message. It MUST be freed after use.
  */
-telebot_error_e telebot_core_send_photo(telebot_core_handler_t *core_h, int chat_id,
+telebot_error_e telebot_core_send_photo(telebot_core_handler_t *core_h, long long int chat_id,
         char *photo, bool is_file, char *caption, bool disable_notification,
         int reply_to_message_id, char *reply_markup);
 /**
@@ -234,7 +234,7 @@ telebot_error_e telebot_core_send_photo(telebot_core_handler_t *core_h, int chat
  * error value. Response is placed in core_h->resp_data that contains the sent
  * message. It MUST be freed after use.
  */
-telebot_error_e telebot_core_send_audio(telebot_core_handler_t *core_h, int chat_id,
+telebot_error_e telebot_core_send_audio(telebot_core_handler_t *core_h, long long int chat_id,
         char *audio, bool is_file, int duration, char *performer, char *title,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
@@ -256,7 +256,7 @@ telebot_error_e telebot_core_send_audio(telebot_core_handler_t *core_h, int chat
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_document(telebot_core_handler_t *core_h,
-        int chat_id, char *document, bool is_file, bool disable_notification,
+        long long int chat_id, char *document, bool is_file, bool disable_notification,
         int reply_to_message_id, char *reply_markup);
 
 /**
@@ -280,7 +280,7 @@ telebot_error_e telebot_core_send_document(telebot_core_handler_t *core_h,
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_video(telebot_core_handler_t *core_h,
-        int chat_id, char *video, bool is_file, int duration, char *caption,
+        long long int chat_id, char *video, bool is_file, int duration, char *caption,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
 /**
@@ -306,7 +306,7 @@ telebot_error_e telebot_core_send_video(telebot_core_handler_t *core_h,
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_voice(telebot_core_handler_t *core_h,
-        int chat_id, char *voice, bool is_file, int duration,
+        long long int chat_id, char *voice, bool is_file, int duration,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
 /**
@@ -330,7 +330,7 @@ telebot_error_e telebot_core_send_voice(telebot_core_handler_t *core_h,
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_video_note(telebot_core_handler_t *core_h,
-        int chat_id, char *video_note, bool is_file, int duration, int length,
+        long long int chat_id, char *video_note, bool is_file, int duration, int length,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
 /**
@@ -350,7 +350,7 @@ telebot_error_e telebot_core_send_video_note(telebot_core_handler_t *core_h,
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_location(telebot_core_handler_t *core_h,
-        int chat_id, float latitude, float longitude, bool disable_notification,
+        long long int chat_id, float latitude, float longitude, bool disable_notification,
         int reply_to_message_id, char *reply_markup);
 
 /**
@@ -375,7 +375,7 @@ telebot_error_e telebot_core_send_location(telebot_core_handler_t *core_h,
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_edit_message_live_location(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, float latitude,
+        long long int chat_id, int message_id, char *inline_message_id, float latitude,
         float longitude, bool disable_notification, char *reply_markup);
 
 /**
@@ -394,7 +394,7 @@ telebot_error_e telebot_core_edit_message_live_location(telebot_core_handler_t *
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_stop_message_live_location(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, char *reply_markup);
+        long long int chat_id, int message_id, char *inline_message_id, char *reply_markup);
 
 /**
  * @brief This function is used to send information about a venue.
@@ -417,7 +417,7 @@ telebot_error_e telebot_core_stop_message_live_location(telebot_core_handler_t *
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_venue(telebot_core_handler_t *core_h,
-        int chat_id, float latitude, float longitude, char *title, char *address,
+        long long int chat_id, float latitude, float longitude, char *title, char *address,
         char *foursquare_id, bool disable_notification, int reply_to_message_id,
         char *reply_markup);
 
@@ -440,7 +440,7 @@ telebot_error_e telebot_core_send_venue(telebot_core_handler_t *core_h,
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_contact(telebot_core_handler_t *core_h,
-        int chat_id, char *phone_number, char *first_name, char *last_name,
+        long long int chat_id, char *phone_number, char *first_name, char *last_name,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
 /**
@@ -466,7 +466,7 @@ telebot_error_e telebot_core_send_contact(telebot_core_handler_t *core_h,
  * message. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_chat_action(telebot_core_handler_t *core_h,
-        int chat_id, char *action);
+        long long int chat_id, char *action);
 
 /**
  * @brief This function is used to get user profile pictures object
@@ -526,7 +526,7 @@ telebot_error_e telebot_core_download_file(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_kick_chat_member(telebot_core_handler_t *core_h,
-        int chat_id, int user_id, long until_date);
+        long long int chat_id, int user_id, long until_date);
 
 /**
  * @brief This function is used to unban a previously kicked user in
@@ -542,7 +542,7 @@ telebot_error_e telebot_core_kick_chat_member(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_unban_chat_member(telebot_core_handler_t *core_h,
-        int chat_id, int user_id);
+        long long int chat_id, int user_id);
 
 /**
  * @brief This function is used to restrict a user in a supergroup. The bot
@@ -567,7 +567,7 @@ telebot_error_e telebot_core_unban_chat_member(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_restrict_chat_member(telebot_core_handler_t *core_h,
-        int chat_id, int user_id, long until_date, bool can_send_messages,
+        long long int chat_id, int user_id, long until_date, bool can_send_messages,
         bool can_send_media_messages, bool can_send_other_messages,
         bool can_add_web_page_previews);
 
@@ -603,7 +603,7 @@ telebot_error_e telebot_core_restrict_chat_member(telebot_core_handler_t *core_h
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_promote_chat_member(telebot_core_handler_t *core_h,
-        int chat_id, int user_id, bool can_post_messages, bool can_edit_messages,
+        long long int chat_id, int user_id, bool can_post_messages, bool can_edit_messages,
         bool can_delete_messages, bool can_invite_users, bool can_restrict_members,
         bool can_pin_messages, bool can_promote_members);
 
@@ -619,7 +619,7 @@ telebot_error_e telebot_core_promote_chat_member(telebot_core_handler_t *core_h,
  * invite link. It MUST be freed after use.
  */
 telebot_error_e telebot_core_export_chat_invite_link(telebot_core_handler_t *core_h,
-        int chat_id);
+        long long int chat_id);
 
 /**
  * @brief This function is used to set a new profile photo for the chat. Photos
@@ -634,7 +634,7 @@ telebot_error_e telebot_core_export_chat_invite_link(telebot_core_handler_t *cor
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_set_chat_photo(telebot_core_handler_t *core_h,
-        int chat_id, char *photo);
+        long long int chat_id, char *photo);
 
 /**
  * @brief This function is used to delete a chat photo. Photos can't be changed
@@ -648,7 +648,7 @@ telebot_error_e telebot_core_set_chat_photo(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_delete_chat_photo(telebot_core_handler_t *core_h,
-        int chat_id, char *photo);
+        long long int chat_id, char *photo);
 
 /**
  * @brief This function is used to change the title of a chat. Titles can't be
@@ -663,7 +663,7 @@ telebot_error_e telebot_core_delete_chat_photo(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_set_chat_title(telebot_core_handler_t *core_h,
-        int chat_id, char *title);
+        long long int chat_id, char *title);
 
 /**
  * @brief This function is used to change the description of a supergroup or
@@ -678,7 +678,7 @@ telebot_error_e telebot_core_set_chat_title(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_set_chat_description(telebot_core_handler_t *core_h,
-        int chat_id, char *description);
+        long long int chat_id, char *description);
 
 /**
  * @brief This function is used to pin a message in a supergroup or a channel.
@@ -697,7 +697,7 @@ telebot_error_e telebot_core_set_chat_description(telebot_core_handler_t *core_h
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_pin_chat_message(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, bool disable_notification);
+        long long int chat_id, int message_id, bool disable_notification);
 
 /**
  * @brief This function is used to unpin a message in a supergroup or a channel.
@@ -712,7 +712,7 @@ telebot_error_e telebot_core_pin_chat_message(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_unpin_chat_message(telebot_core_handler_t *core_h,
-        int chat_id);
+        long long int chat_id);
 
 /**
  * @brief This function is used to leave a group, supergroup or channel.
@@ -724,7 +724,7 @@ telebot_error_e telebot_core_unpin_chat_message(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_leave_chat(telebot_core_handler_t *core_h,
-        int chat_id);
+        long long int chat_id);
 
 /**
  * @brief This function is used to to get up to date information about the
@@ -738,7 +738,7 @@ telebot_error_e telebot_core_leave_chat(telebot_core_handler_t *core_h,
  * information. It MUST be freed after use.
  */
 telebot_error_e telebot_core_get_chat(telebot_core_handler_t *core_h,
-        int chat_id);
+        long long int chat_id);
 
 /**
  * @brief This function is used to get a list of administrators in a chat.
@@ -753,7 +753,7 @@ telebot_error_e telebot_core_get_chat(telebot_core_handler_t *core_h,
  * chat members. It MUST be freed after use.
  */
 telebot_error_e telebot_core_get_chat_admins(telebot_core_handler_t *core_h,
-        int chat_id);
+        long long int chat_id);
 
 /**
  * @brief This function is used to get the number of members in a chat.
@@ -765,7 +765,7 @@ telebot_error_e telebot_core_get_chat_admins(telebot_core_handler_t *core_h,
  * of chat members. It MUST be freed after use.
  */
 telebot_error_e telebot_core_get_chat_members_count(telebot_core_handler_t *core_h,
-        int chat_id);
+        long long int chat_id);
 
 /**
  * @brief This function is used to get information about a member of a chat.
@@ -777,7 +777,7 @@ telebot_error_e telebot_core_get_chat_members_count(telebot_core_handler_t *core
  * member. It MUST be freed after use.
  */
 telebot_error_e telebot_core_get_chat_member(telebot_core_handler_t *core_h,
-        int chat_id);
+        long long int chat_id);
 
 /**
  * @brief This function is used to set a new group sticker set for a supergroup.
@@ -794,7 +794,7 @@ telebot_error_e telebot_core_get_chat_member(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_set_chat_sticker_set(telebot_core_handler_t *core_h,
-        int chat_id, char *sticker_set_name);
+        long long int chat_id, char *sticker_set_name);
 
 /**
  * @brief This function is used to delete a group sticker set from a supergroup.
@@ -809,7 +809,7 @@ telebot_error_e telebot_core_set_chat_sticker_set(telebot_core_handler_t *core_h
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_delete_chat_sticker_set(telebot_core_handler_t *core_h,
-        int chat_id);
+        long long int chat_id);
 
 /**
  * @brief Send answers to callback queries sent from inline keyboards.
@@ -856,7 +856,7 @@ telebot_error_e telebot_core_answer_callback_query(telebot_core_handler_t *core_
  * message, if the message is edited, otherwise "true". It MUST be freed after use.
  */
 telebot_error_e telebot_core_edit_message_text(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, char *text,
+        long long int chat_id, int message_id, char *inline_message_id, char *text,
         char *parse_mode, bool disable_web_page_preview, char *reply_markup);
 
 /**
@@ -876,7 +876,7 @@ telebot_error_e telebot_core_edit_message_text(telebot_core_handler_t *core_h,
  * message, if the message is edited, otherwise "true". It MUST be freed after use.
  */
 telebot_error_e telebot_core_edit_message_caption(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, char *caption,
+        long long int chat_id, int message_id, char *inline_message_id, char *caption,
         char *reply_markup);
 
 /**
@@ -896,7 +896,7 @@ telebot_error_e telebot_core_edit_message_caption(telebot_core_handler_t *core_h
  */
 
 telebot_error_e telebot_core_edit_message_reply_markup(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, char *reply_markup);
+        long long int chat_id, int message_id, char *inline_message_id, char *reply_markup);
 
 /**
  * @brief This function is used to delete a message, including service messages,
@@ -916,7 +916,7 @@ telebot_error_e telebot_core_edit_message_reply_markup(telebot_core_handler_t *c
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_delete_message(telebot_core_handler_t *core_h,
-        int chat_id, int message_id);
+        long long int chat_id, int message_id);
 
 /**
  * @brief This function is used to to send .webp stickers.
@@ -937,7 +937,7 @@ telebot_error_e telebot_core_delete_message(telebot_core_handler_t *core_h,
  * successfull. It MUST be freed after use.
  */
 telebot_error_e telebot_core_send_sticker(telebot_core_handler_t *core_h,
-        int chat_id, char *sticker, bool is_file, bool disable_notification,
+        long long int chat_id, char *sticker, bool is_file, bool disable_notification,
         int reply_to_message_id, char *reply_markup);
 
 /**

--- a/include/telebot-methods.h
+++ b/include/telebot-methods.h
@@ -188,7 +188,7 @@ telebot_error_e telebot_free_me(telebot_user_t *me);
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_message(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_message(telebot_handler_t handle, long long int chat_id,
         char *text, char *parse_mode, bool disable_web_page_preview,
         bool disable_notification, int reply_to_message_id, const char *reply_markup);
 
@@ -206,15 +206,15 @@ telebot_error_e telebot_send_message(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_forward_message(telebot_handler_t handle, int chat_id,
-        int from_chat_id, bool disable_notification, int message_id);
+telebot_error_e telebot_forward_message(telebot_handler_t handle, long long int chat_id,
+        long long int from_chat_id, bool disable_notification, int message_id);
 
 /**
  * @brief This functionis used to send photos.
  *
  * @param[in] handle The telebot handler created with #telebot_create().
  * @param[in] chat_id Unique identifier for the target chat or username of the
- * target channel (in the format \@channelusername).int chat_id
+ * target channel (in the format \@channelusername).long long int chat_id
  * @param[in] photo Photo to send. It is either file_id to resend a photo
  * that is already on the Telegram servers, or a path to photo file.
  * @param[in] is_file False if photo is file_id, true, if photo is a file path.
@@ -228,7 +228,7 @@ telebot_error_e telebot_forward_message(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_photo(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_photo(telebot_handler_t handle, long long int chat_id,
         char *photo, bool is_file, char *caption, bool disable_notification,
         int reply_to_message_id, char *reply_markup);
 
@@ -260,7 +260,7 @@ telebot_error_e telebot_send_photo(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_audio(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_audio(telebot_handler_t handle, long long int chat_id,
         char *audio, bool is_file, int duration, char *performer, char *title,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
@@ -283,7 +283,7 @@ telebot_error_e telebot_send_audio(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_document(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_document(telebot_handler_t handle, long long int chat_id,
         char *document, bool is_file, bool disable_notification,
         int reply_to_message_id, char *reply_markup);
 
@@ -310,7 +310,7 @@ telebot_error_e telebot_send_document(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_video(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_video(telebot_handler_t handle, long long int chat_id,
         char *video, bool is_file, int duration, int width, int height,
         char *caption, bool disable_notification, int reply_to_message_id,
         char *reply_markup);
@@ -339,7 +339,7 @@ telebot_error_e telebot_send_video(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_voice(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_voice(telebot_handler_t handle, long long int chat_id,
         char *voice, bool is_file, char *caption, int duration,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
@@ -363,7 +363,7 @@ telebot_error_e telebot_send_voice(telebot_handler_t handle, int chat_id,
  * keyboard, instructions to hide keyboard or to force a reply from the user.
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative error value.
  */
-telebot_error_e telebot_send_video_note(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_video_note(telebot_handler_t handle, long long int chat_id,
         char *video_note, bool is_file, int duration, int length,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
@@ -384,7 +384,7 @@ telebot_error_e telebot_send_video_note(telebot_handler_t handle, int chat_id,
  * error value.
  */
 /* TODO
- * telebot_error_e telebot_send_media_group(telebot_handler_t handle, int chat_id,
+ * telebot_error_e telebot_send_media_group(telebot_handler_t handle, long long int chat_id,
  *        telebot_input_media_t media[], bool is_file, bool disable_notification,
  *        int reply_to_message_id);
  */
@@ -406,7 +406,7 @@ telebot_error_e telebot_send_video_note(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_location(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_location(telebot_handler_t handle, long long int chat_id,
         float latitude, float longitude, bool disable_notification,
         int reply_to_message_id, char *reply_markup);
 
@@ -433,7 +433,7 @@ telebot_error_e telebot_send_location(telebot_handler_t handle, int chat_id,
  * error value.
  */
 telebot_error_e telebot_edit_message_live_location(telebot_handler_t handle,
-        int chat_id, int message_id, char *inline_message_id, float latitude,
+        long long int chat_id, int message_id, char *inline_message_id, float latitude,
         float longitude, bool disable_notification, char *reply_markup);
 
 /**
@@ -452,7 +452,7 @@ telebot_error_e telebot_edit_message_live_location(telebot_handler_t handle,
  * error value.
  */
 telebot_error_e telebot_stop_message_live_location(telebot_handler_t handle,
-        int chat_id, int message_id, char *inline_message_id, char *reply_markup);
+        long long int chat_id, int message_id, char *inline_message_id, char *reply_markup);
 
 /**
  * @brief This function is used to send information about a venue.
@@ -475,7 +475,7 @@ telebot_error_e telebot_stop_message_live_location(telebot_handler_t handle,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_venue(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_venue(telebot_handler_t handle, long long int chat_id,
         float latitude, float longitude, char *title, char *foursquare_id,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
@@ -498,7 +498,7 @@ telebot_error_e telebot_send_venue(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_contact(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_contact(telebot_handler_t handle, long long int chat_id,
         char *phone_number, char *first_name, char *last_name,
         bool disable_notification, int reply_to_message_id, char *reply_markup);
 
@@ -525,7 +525,7 @@ telebot_error_e telebot_send_contact(telebot_handler_t handle, int chat_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_chat_action(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_chat_action(telebot_handler_t handle, long long int chat_id,
         char *action);
 
 /**
@@ -573,7 +573,7 @@ telebot_error_e telebot_download_file(telebot_handler_t handle, char *file_id,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_delete_message(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_delete_message(telebot_handler_t handle, long long int chat_id,
         int message_id);
 
 /**
@@ -616,7 +616,7 @@ telebot_error_e telebot_answer_callback_query(telebot_handler_t handle,
  * @return on Success, TELEBOT_ERROR_NONE is returned, otherwise a negative
  * error value.
  */
-telebot_error_e telebot_send_sticker(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_sticker(telebot_handler_t handle, long long int chat_id,
         char *sticker, bool is_file, bool disable_notification,
         int reply_to_message_id, char *reply_markup);
 

--- a/include/telebot-types.h
+++ b/include/telebot-types.h
@@ -81,7 +81,7 @@ typedef struct telebot_user {
  */
 typedef struct telebot_chat {
     /** Unique identifier for this chat, it may be greater than 32 bits. */
-    long long id;
+    long long int id;
 
     /** Type of chat, can be either "private", or "group", "supergroup", or "channel". */
     char *type;
@@ -269,13 +269,13 @@ typedef struct telebot_message {
      * Optional. The group has been migrated to a supergroup with the specified
      * identifier, not exceeding 1e13 by absolute value
      */
-    int migrate_to_chat_id;
+    long long int migrate_to_chat_id;
 
     /**
      * Optional. The supergroup has been migrated from a group with the
      * specified identifier, not exceeding 1e13 by absolute value
      */
-    int migrate_from_chat_id;
+    long long int migrate_from_chat_id;
 
     /**
      * Optional. Specified message was pinned. Note that the Message object in

--- a/src/telebot-core.c
+++ b/src/telebot-core.c
@@ -249,7 +249,7 @@ telebot_error_e telebot_core_get_me(telebot_core_handler_t *core_h)
 }
 
 telebot_error_e telebot_core_send_message(telebot_core_handler_t *core_h,
-        int chat_id, char *text, char *parse_mode, bool disable_web_page_preview,
+        long long int chat_id, char *text, char *parse_mode, bool disable_web_page_preview,
         bool disable_notification, int reply_to_message_id, const char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (text == NULL)) {
@@ -261,7 +261,7 @@ telebot_error_e telebot_core_send_message(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "text",
@@ -290,7 +290,7 @@ telebot_error_e telebot_core_send_message(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_forward_message(telebot_core_handler_t *core_h,
-        int chat_id, int from_chat_id, bool disable_notification, int message_id)
+        long long int chat_id, long long int from_chat_id, bool disable_notification, int message_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler or token is NULL.");
@@ -306,7 +306,7 @@ telebot_error_e telebot_core_forward_message(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     curl_formadd (&post, &last, CURLFORM_COPYNAME, "from_chat_id",
@@ -324,7 +324,7 @@ telebot_error_e telebot_core_forward_message(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_photo(telebot_core_handler_t *core_h,
-        int chat_id, char *photo, bool is_file, char *caption,
+        long long int chat_id, char *photo, bool is_file, char *caption,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (photo == NULL)) {
@@ -341,7 +341,7 @@ telebot_error_e telebot_core_send_photo(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     if (is_file)
@@ -371,7 +371,7 @@ telebot_error_e telebot_core_send_photo(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_audio(telebot_core_handler_t *core_h,
-        int chat_id, char *audio, bool is_file, int duration, char *performer,
+        long long int chat_id, char *audio, bool is_file, int duration, char *performer,
         char *title, bool disable_notification, int reply_to_message_id,
         char *reply_markup)
 {
@@ -389,7 +389,7 @@ telebot_error_e telebot_core_send_audio(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     if (is_file)
@@ -428,7 +428,7 @@ telebot_error_e telebot_core_send_audio(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_document(telebot_core_handler_t *core_h,
-        int chat_id, char *document, bool is_file, bool disable_notification,
+        long long int chat_id, char *document, bool is_file, bool disable_notification,
         int reply_to_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (document == NULL)) {
@@ -445,7 +445,7 @@ telebot_error_e telebot_core_send_document(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     if (is_file)
@@ -472,7 +472,7 @@ telebot_error_e telebot_core_send_document(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_video(telebot_core_handler_t *core_h,
-        int chat_id, char *video, bool is_file, int duration, char *caption,
+        long long int chat_id, char *video, bool is_file, int duration, char *caption,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (video == NULL)) {
@@ -489,7 +489,7 @@ telebot_error_e telebot_core_send_video(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     if (is_file)
@@ -525,7 +525,7 @@ telebot_error_e telebot_core_send_video(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_voice(telebot_core_handler_t *core_h,
-        int chat_id, char *voice, bool is_file, int duration,
+        long long int chat_id, char *voice, bool is_file, int duration,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (voice == NULL)) {
@@ -542,7 +542,7 @@ telebot_error_e telebot_core_send_voice(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     if (is_file)
@@ -575,7 +575,7 @@ telebot_error_e telebot_core_send_voice(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_video_note(telebot_core_handler_t *core_h,
-        int chat_id, char *video_note, bool is_file, int duration, int length,
+        long long int chat_id, char *video_note, bool is_file, int duration, int length,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (video_note == NULL)) {
@@ -592,7 +592,7 @@ telebot_error_e telebot_core_send_video_note(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     if (is_file)
@@ -632,7 +632,7 @@ telebot_error_e telebot_core_send_video_note(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_location(telebot_core_handler_t *core_h,
-        int chat_id, float latitude, float longitude, bool disable_notification,
+        long long int chat_id, float latitude, float longitude, bool disable_notification,
         int reply_to_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
@@ -649,7 +649,7 @@ telebot_error_e telebot_core_send_location(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     char latitude_str[32];
@@ -678,7 +678,7 @@ telebot_error_e telebot_core_send_location(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_edit_message_live_location(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, float latitude,
+        long long int chat_id, int message_id, char *inline_message_id, float latitude,
         float longitude, bool disable_notification, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
@@ -696,7 +696,7 @@ telebot_error_e telebot_core_edit_message_live_location(telebot_core_handler_t *
 
     if (chat_id > 0) {
         char chat_id_str[16];
-        snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+        snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
                 CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     }
@@ -729,7 +729,7 @@ telebot_error_e telebot_core_edit_message_live_location(telebot_core_handler_t *
 }
 
 telebot_error_e telebot_core_stop_message_live_location(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, char *reply_markup)
+        long long int chat_id, int message_id, char *inline_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler or token is NULL");
@@ -746,7 +746,7 @@ telebot_error_e telebot_core_stop_message_live_location(telebot_core_handler_t *
 
     if (chat_id > 0) {
         char chat_id_str[16];
-        snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+        snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
                 CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     }
@@ -768,7 +768,7 @@ telebot_error_e telebot_core_stop_message_live_location(telebot_core_handler_t *
 }
 
 telebot_error_e telebot_core_send_venue(telebot_core_handler_t *core_h,
-        int chat_id,float latitude, float longitude, char *title, char *address,
+        long long int chat_id,float latitude, float longitude, char *title, char *address,
         char *foursquare_id, bool disable_notification, int reply_to_message_id,
         char *reply_markup)
 {
@@ -787,7 +787,7 @@ telebot_error_e telebot_core_send_venue(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     char latitude_str[32];
@@ -823,7 +823,7 @@ telebot_error_e telebot_core_send_venue(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_contact(telebot_core_handler_t *core_h,
-        int chat_id, char *phone_number, char *first_name, char *last_name,
+        long long int chat_id, char *phone_number, char *first_name, char *last_name,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (phone_number == NULL)
@@ -841,7 +841,7 @@ telebot_error_e telebot_core_send_contact(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "phone_number",
@@ -869,7 +869,7 @@ telebot_error_e telebot_core_send_contact(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_chat_action(telebot_core_handler_t *core_h,
-        int chat_id, char *action)
+        long long int chat_id, char *action)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (action == NULL)) {
         ERR("Handler, token or action is NULL");
@@ -885,7 +885,7 @@ telebot_error_e telebot_core_send_chat_action(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "action",
@@ -1000,7 +1000,7 @@ telebot_error_e telebot_core_download_file(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_kick_chat_member(telebot_core_handler_t *core_h,
-        int chat_id, int user_id, long until_date)
+        long long int chat_id, int user_id, long until_date)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1016,7 +1016,7 @@ telebot_error_e telebot_core_kick_chat_member(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     char user_id_str[16];
@@ -1033,7 +1033,7 @@ telebot_error_e telebot_core_kick_chat_member(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_unban_chat_member(telebot_core_handler_t *core_h,
-        int chat_id, int user_id)
+        long long int chat_id, int user_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1049,7 +1049,7 @@ telebot_error_e telebot_core_unban_chat_member(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     char user_id_str[16];
@@ -1062,7 +1062,7 @@ telebot_error_e telebot_core_unban_chat_member(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_restrict_chat_member(telebot_core_handler_t *core_h,
-        int chat_id, int user_id, long until_date, bool can_send_messages,
+        long long int chat_id, int user_id, long until_date, bool can_send_messages,
         bool can_send_media_messages, bool can_send_other_messages,
         bool can_add_web_page_previews)
 {
@@ -1080,7 +1080,7 @@ telebot_error_e telebot_core_restrict_chat_member(telebot_core_handler_t *core_h
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     char user_id_str[16];
@@ -1109,7 +1109,7 @@ telebot_error_e telebot_core_restrict_chat_member(telebot_core_handler_t *core_h
 }
 
 telebot_error_e telebot_core_promote_chat_member(telebot_core_handler_t *core_h,
-        int chat_id, int user_id, bool can_post_messages, bool can_edit_messages,
+        long long int chat_id, int user_id, bool can_post_messages, bool can_edit_messages,
         bool can_delete_messages, bool can_invite_users, bool can_restrict_members,
         bool can_pin_messages, bool can_promote_members)
 {
@@ -1127,7 +1127,7 @@ telebot_error_e telebot_core_promote_chat_member(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     char user_id_str[16];
@@ -1161,7 +1161,7 @@ telebot_error_e telebot_core_promote_chat_member(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_export_chat_invite_link(telebot_core_handler_t *core_h,
-        int chat_id)
+        long long int chat_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1177,7 +1177,7 @@ telebot_error_e telebot_core_export_chat_invite_link(telebot_core_handler_t *cor
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     return telebot_core_curl_perform(core_h,
@@ -1185,7 +1185,7 @@ telebot_error_e telebot_core_export_chat_invite_link(telebot_core_handler_t *cor
 }
 
 telebot_error_e telebot_core_set_chat_photo(telebot_core_handler_t *core_h,
-        int chat_id, char *photo)
+        long long int chat_id, char *photo)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1201,7 +1201,7 @@ telebot_error_e telebot_core_set_chat_photo(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "photo",
@@ -1212,7 +1212,7 @@ telebot_error_e telebot_core_set_chat_photo(telebot_core_handler_t *core_h,
 
 
 telebot_error_e telebot_core_delete_chat_photo(telebot_core_handler_t *core_h,
-        int chat_id, char *photo)
+        long long int chat_id, char *photo)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1228,7 +1228,7 @@ telebot_error_e telebot_core_delete_chat_photo(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     return telebot_core_curl_perform(core_h,
@@ -1237,7 +1237,7 @@ telebot_error_e telebot_core_delete_chat_photo(telebot_core_handler_t *core_h,
 
 
 telebot_error_e telebot_core_set_chat_title(telebot_core_handler_t *core_h,
-        int chat_id, char *title)
+        long long int chat_id, char *title)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1253,7 +1253,7 @@ telebot_error_e telebot_core_set_chat_title(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "title",
@@ -1264,7 +1264,7 @@ telebot_error_e telebot_core_set_chat_title(telebot_core_handler_t *core_h,
 
 
 telebot_error_e telebot_core_set_chat_description(telebot_core_handler_t *core_h,
-        int chat_id, char *description)
+        long long int chat_id, char *description)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1280,7 +1280,7 @@ telebot_error_e telebot_core_set_chat_description(telebot_core_handler_t *core_h
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     if (description)
@@ -1291,7 +1291,7 @@ telebot_error_e telebot_core_set_chat_description(telebot_core_handler_t *core_h
 }
 
 telebot_error_e telebot_core_pin_chat_message(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, bool disable_notification)
+        long long int chat_id, int message_id, bool disable_notification)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1307,7 +1307,7 @@ telebot_error_e telebot_core_pin_chat_message(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     char message_id_str[16];
@@ -1323,7 +1323,7 @@ telebot_error_e telebot_core_pin_chat_message(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_unpin_chat_message(telebot_core_handler_t *core_h,
-        int chat_id)
+        long long int chat_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1339,7 +1339,7 @@ telebot_error_e telebot_core_unpin_chat_message(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
 
@@ -1349,7 +1349,7 @@ telebot_error_e telebot_core_unpin_chat_message(telebot_core_handler_t *core_h,
 
 
 telebot_error_e telebot_core_leave_chat(telebot_core_handler_t *core_h,
-        int chat_id)
+        long long int chat_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1365,7 +1365,7 @@ telebot_error_e telebot_core_leave_chat(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
 
@@ -1374,7 +1374,7 @@ telebot_error_e telebot_core_leave_chat(telebot_core_handler_t *core_h,
 
 
 telebot_error_e telebot_core_get_chat(telebot_core_handler_t *core_h,
-        int chat_id)
+        long long int chat_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1390,7 +1390,7 @@ telebot_error_e telebot_core_get_chat(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
 
@@ -1398,7 +1398,7 @@ telebot_error_e telebot_core_get_chat(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_get_chat_admins(telebot_core_handler_t *core_h,
-        int chat_id)
+        long long int chat_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1414,7 +1414,7 @@ telebot_error_e telebot_core_get_chat_admins(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
 
@@ -1422,7 +1422,7 @@ telebot_error_e telebot_core_get_chat_admins(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_get_chat_members_count(telebot_core_handler_t *core_h,
-        int chat_id)
+        long long int chat_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1438,7 +1438,7 @@ telebot_error_e telebot_core_get_chat_members_count(telebot_core_handler_t *core
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
 
@@ -1447,7 +1447,7 @@ telebot_error_e telebot_core_get_chat_members_count(telebot_core_handler_t *core
 }
 
 telebot_error_e telebot_core_get_chat_member(telebot_core_handler_t *core_h,
-        int chat_id)
+        long long int chat_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1463,7 +1463,7 @@ telebot_error_e telebot_core_get_chat_member(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
 
@@ -1472,7 +1472,7 @@ telebot_error_e telebot_core_get_chat_member(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_set_chat_sticker_set(telebot_core_handler_t *core_h,
-        int chat_id, char *sticker_set_name)
+        long long int chat_id, char *sticker_set_name)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1488,7 +1488,7 @@ telebot_error_e telebot_core_set_chat_sticker_set(telebot_core_handler_t *core_h
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "sticker_set_name",
@@ -1499,7 +1499,7 @@ telebot_error_e telebot_core_set_chat_sticker_set(telebot_core_handler_t *core_h
 }
 
 telebot_error_e telebot_core_delete_chat_sticker_set(telebot_core_handler_t *core_h,
-        int chat_id)
+        long long int chat_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
@@ -1515,7 +1515,7 @@ telebot_error_e telebot_core_delete_chat_sticker_set(telebot_core_handler_t *cor
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
 
@@ -1559,7 +1559,7 @@ telebot_error_e telebot_core_answer_callback_query(telebot_core_handler_t * core
 }
 
 telebot_error_e telebot_core_edit_message_text(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, char *text,
+        long long int chat_id, int message_id, char *inline_message_id, char *text,
         char *parse_mode, bool disable_web_page_preview, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (text == NULL)) {
@@ -1577,7 +1577,7 @@ telebot_error_e telebot_core_edit_message_text(telebot_core_handler_t *core_h,
 
     if (chat_id > 0) {
         char chat_id_str[16];
-        snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+        snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
                 CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     }
@@ -1607,7 +1607,7 @@ telebot_error_e telebot_core_edit_message_text(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_edit_message_caption(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, char *caption,
+        long long int chat_id, int message_id, char *inline_message_id, char *caption,
         char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
@@ -1625,7 +1625,7 @@ telebot_error_e telebot_core_edit_message_caption(telebot_core_handler_t *core_h
 
     if (chat_id > 0) {
         char chat_id_str[16];
-        snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+        snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
                 CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     }
@@ -1651,7 +1651,7 @@ telebot_error_e telebot_core_edit_message_caption(telebot_core_handler_t *core_h
 
 
 telebot_error_e telebot_core_edit_message_reply_markup(telebot_core_handler_t *core_h,
-        int chat_id, int message_id, char *inline_message_id, char *reply_markup)
+        long long int chat_id, int message_id, char *inline_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler or token is NULL");
@@ -1668,7 +1668,7 @@ telebot_error_e telebot_core_edit_message_reply_markup(telebot_core_handler_t *c
 
     if (chat_id > 0) {
         char chat_id_str[16];
-        snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+        snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
                 CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     }
@@ -1690,7 +1690,7 @@ telebot_error_e telebot_core_edit_message_reply_markup(telebot_core_handler_t *c
 }
 
 telebot_error_e telebot_core_delete_message(telebot_core_handler_t *core_h,
-        int chat_id, int message_id)
+        long long int chat_id, int message_id)
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler or token is NULL");
@@ -1706,7 +1706,7 @@ telebot_error_e telebot_core_delete_message(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     char message_id_str[16];
     snprintf(message_id_str, sizeof(message_id_str), "%d", message_id);
 
@@ -1719,7 +1719,7 @@ telebot_error_e telebot_core_delete_message(telebot_core_handler_t *core_h,
 }
 
 telebot_error_e telebot_core_send_sticker(telebot_core_handler_t *core_h,
-        int chat_id, char *sticker, bool is_file, bool disable_notification,
+        long long int chat_id, char *sticker, bool is_file, bool disable_notification,
         int reply_to_message_id, char *reply_markup)
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (sticker == NULL)) {
@@ -1736,7 +1736,7 @@ telebot_error_e telebot_core_send_sticker(telebot_core_handler_t *core_h,
     struct curl_httppost *last = NULL;
 
     char chat_id_str[16];
-    snprintf(chat_id_str, sizeof(chat_id_str), "%d", chat_id);
+    snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
     curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
             CURLFORM_COPYCONTENTS, chat_id_str, CURLFORM_END);
     if (is_file)

--- a/src/telebot-core.c
+++ b/src/telebot-core.c
@@ -297,8 +297,8 @@ telebot_error_e telebot_core_forward_message(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) || (from_chat_id <= 0) || (message_id <= 0)) {
-        ERR("Valid chat_id, from_chat_id and message_id is required.");
+    if (message_id <= 0) {
+        ERR("Valid message_id is required.");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -329,11 +329,6 @@ telebot_error_e telebot_core_send_photo(telebot_core_handler_t *core_h,
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (photo == NULL)) {
         ERR("Handler, token or photo is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -377,11 +372,6 @@ telebot_error_e telebot_core_send_audio(telebot_core_handler_t *core_h,
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (audio == NULL)) {
         ERR("Handler, token or audio is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -436,11 +426,6 @@ telebot_error_e telebot_core_send_document(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -477,11 +462,6 @@ telebot_error_e telebot_core_send_video(telebot_core_handler_t *core_h,
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (video == NULL)) {
         ERR("Handler, token or document is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -533,11 +513,6 @@ telebot_error_e telebot_core_send_voice(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -580,11 +555,6 @@ telebot_error_e telebot_core_send_video_note(telebot_core_handler_t *core_h,
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (video_note == NULL)) {
         ERR("Handler, token or video_note is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -640,11 +610,6 @@ telebot_error_e telebot_core_send_location(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -686,7 +651,7 @@ telebot_error_e telebot_core_edit_message_live_location(telebot_core_handler_t *
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (((chat_id <= 0) || (message_id <=0)) && (inline_message_id == NULL)) {
+    if (((chat_id == 0) || (message_id <= 0)) && (inline_message_id == NULL)) {
         ERR("Either valid chat_id & message_id or inline_message_id required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
@@ -694,7 +659,7 @@ telebot_error_e telebot_core_edit_message_live_location(telebot_core_handler_t *
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
-    if (chat_id > 0) {
+    if (chat_id != 0) {
         char chat_id_str[16];
         snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
@@ -736,7 +701,7 @@ telebot_error_e telebot_core_stop_message_live_location(telebot_core_handler_t *
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (((chat_id <= 0) || (message_id <=0)) && (inline_message_id == NULL)) {
+    if (((chat_id == 0) || (message_id <= 0)) && (inline_message_id == NULL)) {
         ERR("Either valid chat_id & message_id or inline_message_id required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
@@ -744,7 +709,7 @@ telebot_error_e telebot_core_stop_message_live_location(telebot_core_handler_t *
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
-    if (chat_id > 0) {
+    if (chat_id != 0) {
         char chat_id_str[16];
         snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
@@ -775,11 +740,6 @@ telebot_error_e telebot_core_send_venue(telebot_core_handler_t *core_h,
     if ((core_h == NULL) || (core_h->token == NULL) || (title == NULL) ||
             (address == NULL)) {
         ERR("Handler, token, title, or address is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -832,11 +792,6 @@ telebot_error_e telebot_core_send_contact(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -873,11 +828,6 @@ telebot_error_e telebot_core_send_chat_action(telebot_core_handler_t *core_h,
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (action == NULL)) {
         ERR("Handler, token or action is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1007,8 +957,8 @@ telebot_error_e telebot_core_kick_chat_member(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) && (user_id <= 0)) {
-        ERR("Valid chat_id and user_id is required");
+    if (user_id <= 0) {
+        ERR("Valid user_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1040,8 +990,8 @@ telebot_error_e telebot_core_unban_chat_member(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) && (user_id <= 0)) {
-        ERR("Valid chat_id and user_id is required");
+    if (user_id <= 0) {
+        ERR("Valid user_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1071,8 +1021,8 @@ telebot_error_e telebot_core_restrict_chat_member(telebot_core_handler_t *core_h
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) && (user_id <= 0)) {
-        ERR("Valid chat_id and user_id is required");
+    if (user_id <= 0) {
+        ERR("Valid user_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1118,8 +1068,8 @@ telebot_error_e telebot_core_promote_chat_member(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) && (user_id <= 0)) {
-        ERR("Valid chat_id and user_id is required");
+    if (user_id <= 0) {
+        ERR("Valid user_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1168,11 +1118,6 @@ telebot_error_e telebot_core_export_chat_invite_link(telebot_core_handler_t *cor
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -1192,8 +1137,8 @@ telebot_error_e telebot_core_set_chat_photo(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) || (photo == NULL)) {
-        ERR("Valid chat_id and photo is required");
+    if (photo == NULL) {
+        ERR("Valid photo is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1219,11 +1164,6 @@ telebot_error_e telebot_core_delete_chat_photo(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -1244,8 +1184,8 @@ telebot_error_e telebot_core_set_chat_title(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) || (title == NULL) || (strlen(title) > 255)) {
-        ERR("Valid chat_id and title is required");
+    if ((title == NULL) || (strlen(title) > 255)) {
+        ERR("Valid title is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1271,11 +1211,6 @@ telebot_error_e telebot_core_set_chat_description(telebot_core_handler_t *core_h
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -1298,8 +1233,8 @@ telebot_error_e telebot_core_pin_chat_message(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) || (message_id <=0)) {
-        ERR("Valid chat_id and message_id is required");
+    if (message_id <=0) {
+        ERR("Valid message_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1330,11 +1265,6 @@ telebot_error_e telebot_core_unpin_chat_message(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -1353,11 +1283,6 @@ telebot_error_e telebot_core_leave_chat(telebot_core_handler_t *core_h,
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1381,11 +1306,6 @@ telebot_error_e telebot_core_get_chat(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -1405,11 +1325,6 @@ telebot_error_e telebot_core_get_chat_admins(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -1426,11 +1341,6 @@ telebot_error_e telebot_core_get_chat_members_count(telebot_core_handler_t *core
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1454,11 +1364,6 @@ telebot_error_e telebot_core_get_chat_member(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
@@ -1479,8 +1384,8 @@ telebot_error_e telebot_core_set_chat_sticker_set(telebot_core_handler_t *core_h
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) || (sticker_set_name == NULL)) {
-        ERR("Valid chat_id and sticker_set_name is required");
+    if (sticker_set_name == NULL) {
+        ERR("Valid sticker_set_name is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1503,11 +1408,6 @@ telebot_error_e telebot_core_delete_chat_sticker_set(telebot_core_handler_t *cor
 {
     if ((core_h == NULL) || (core_h->token == NULL)) {
         ERR("Handler, or token is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1567,7 +1467,7 @@ telebot_error_e telebot_core_edit_message_text(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (((chat_id <= 0) || (message_id <=0)) && (inline_message_id == NULL)) {
+    if (((chat_id == 0) || (message_id <=0)) && (inline_message_id == NULL)) {
         ERR("Either valid chat_id & message_id or inline_message_id required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
@@ -1575,7 +1475,7 @@ telebot_error_e telebot_core_edit_message_text(telebot_core_handler_t *core_h,
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
-    if (chat_id > 0) {
+    if (chat_id != 0) {
         char chat_id_str[16];
         snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
@@ -1615,7 +1515,7 @@ telebot_error_e telebot_core_edit_message_caption(telebot_core_handler_t *core_h
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (((chat_id <= 0) || (message_id <=0)) && (inline_message_id == NULL)) {
+    if (((chat_id == 0) || (message_id <=0)) && (inline_message_id == NULL)) {
         ERR("Either valid chat_id & message_id or inline_message_id required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
@@ -1623,7 +1523,7 @@ telebot_error_e telebot_core_edit_message_caption(telebot_core_handler_t *core_h
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
-    if (chat_id > 0) {
+    if (chat_id != 0) {
         char chat_id_str[16];
         snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
@@ -1658,7 +1558,7 @@ telebot_error_e telebot_core_edit_message_reply_markup(telebot_core_handler_t *c
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if (((chat_id <= 0) || (message_id <=0)) && (inline_message_id == NULL)) {
+    if (((chat_id == 0) || (message_id <=0)) && (inline_message_id == NULL)) {
         ERR("Either valid chat_id & message_id or inline_message_id required");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
@@ -1666,7 +1566,7 @@ telebot_error_e telebot_core_edit_message_reply_markup(telebot_core_handler_t *c
     struct curl_httppost *post = NULL;
     struct curl_httppost *last = NULL;
 
-    if (chat_id > 0) {
+    if (chat_id != 0) {
         char chat_id_str[16];
         snprintf(chat_id_str, sizeof(chat_id_str), "%lld", chat_id);
         curl_formadd(&post, &last, CURLFORM_COPYNAME, "chat_id",
@@ -1697,8 +1597,8 @@ telebot_error_e telebot_core_delete_message(telebot_core_handler_t *core_h,
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
-    if ((chat_id <= 0) || (message_id) <= 0) {
-        ERR("chat_id or message_id is invalid");
+    if ((message_id) <= 0) {
+        ERR("message_id is invalid");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 
@@ -1724,11 +1624,6 @@ telebot_error_e telebot_core_send_sticker(telebot_core_handler_t *core_h,
 {
     if ((core_h == NULL) || (core_h->token == NULL) || (sticker == NULL)) {
         ERR("Handler, token or sticker is NULL");
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-    }
-
-    if (chat_id <= 0) {
-        ERR("Valid chat_id is required.");
         return TELEBOT_ERROR_INVALID_PARAMETER;
     }
 

--- a/src/telebot-parser.c
+++ b/src/telebot-parser.c
@@ -240,7 +240,7 @@ telebot_error_e telebot_parser_get_chat(struct json_object *obj,
     int ret;
     struct json_object *id;
     if (json_object_object_get_ex(obj, "id", &id)) {
-        chat->id = json_object_get_int(id);
+        chat->id = json_object_get_int64(id);
     }
     else {
         ERR("Object is not chat type, id not found");
@@ -591,12 +591,12 @@ telebot_error_e telebot_parser_get_message(struct json_object *obj,
 
     struct json_object *mtci;
     if (json_object_object_get_ex(obj, "migrate_to_chat_id", &mtci)) {
-        msg->migrate_to_chat_id = json_object_get_int(mtci);
+        msg->migrate_to_chat_id = json_object_get_int64(mtci);
     }
 
     struct json_object *mftci;
     if (json_object_object_get_ex(obj, "migrate_from_chat_id", &mftci)) {
-        msg->migrate_from_chat_id = json_object_get_int(mftci);
+        msg->migrate_from_chat_id = json_object_get_int64(mftci);
     }
 
     struct json_object *pinned_message;

--- a/src/telebot.c
+++ b/src/telebot.c
@@ -415,7 +415,7 @@ telebot_error_e telebot_send_message(telebot_handler_t handle, long long int cha
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) || (text == NULL))
+    if (text == NULL)
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_message(_handle->core_h, chat_id,
@@ -434,7 +434,7 @@ telebot_error_e telebot_forward_message(telebot_handler_t handle, long long int 
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) || (message_id <= 0))
+    if (message_id <= 0)
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_forward_message(_handle->core_h, chat_id,
@@ -453,7 +453,7 @@ telebot_error_e telebot_send_photo(telebot_handler_t handle, long long int chat_
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) || (photo == NULL))
+    if (photo == NULL)
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_photo(_handle->core_h, chat_id, photo,
@@ -472,7 +472,7 @@ telebot_error_e telebot_send_audio(telebot_handler_t handle, long long int chat_
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) ||  (audio == NULL))
+    if (audio == NULL)
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_audio(_handle->core_h, chat_id, audio,
@@ -492,7 +492,7 @@ telebot_error_e telebot_send_document(telebot_handler_t handle, long long int ch
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) || (document == NULL))
+    if (document == NULL)
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_document(_handle->core_h, chat_id,
@@ -512,7 +512,7 @@ telebot_error_e telebot_send_video(telebot_handler_t handle, long long int chat_
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) || (video == NULL))
+    if (video == NULL)
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_video(_handle->core_h, chat_id, video,
@@ -532,7 +532,7 @@ telebot_error_e telebot_send_voice(telebot_handler_t handle, long long int chat_
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) || (voice == NULL))
+    if (voice == NULL)
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_voice(_handle->core_h, chat_id, voice,
@@ -551,7 +551,7 @@ telebot_error_e telebot_send_video_note(telebot_handler_t handle, long long int 
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) || (video_note == NULL))
+    if (video_note == NULL)
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_video_note(_handle->core_h, chat_id,
@@ -571,9 +571,6 @@ telebot_error_e telebot_send_location(telebot_handler_t handle, long long int ch
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if (chat_id <= 0)
-        return TELEBOT_ERROR_INVALID_PARAMETER;
-
     telebot_error_e ret = telebot_core_send_location(_handle->core_h, chat_id,
             latitude, longitude, disable_notification, reply_to_message_id, reply_markup);
 
@@ -590,7 +587,7 @@ telebot_error_e telebot_send_contact(telebot_handler_t handle, long long int cha
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
 
-    if ((chat_id <= 0) || (phone_number == NULL) || (first_name == NULL))
+    if ((phone_number == NULL) || (first_name == NULL))
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_contact(_handle->core_h, chat_id,
@@ -608,9 +605,6 @@ telebot_error_e telebot_send_chat_action(telebot_handler_t handle, long long int
     telebot_hdata_t * _handle = (telebot_hdata_t *)handle;
     if (_handle == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
-
-    if (chat_id <= 0)
-        return TELEBOT_ERROR_INVALID_PARAMETER;
 
     telebot_error_e ret = telebot_core_send_chat_action(_handle->core_h,
             chat_id, action);

--- a/src/telebot.c
+++ b/src/telebot.c
@@ -406,7 +406,7 @@ telebot_error_e telebot_free_webhook_info(telebot_webhook_info_t *info)
     return TELEBOT_ERROR_NONE;
 }
 
-telebot_error_e telebot_send_message(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_message(telebot_handler_t handle, long long int chat_id,
         char *text, char *parse_mode, bool disable_web_page_preview,
         bool disable_notification, int reply_to_message_id,
         const char *reply_markup)
@@ -427,8 +427,8 @@ telebot_error_e telebot_send_message(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_forward_message(telebot_handler_t handle, int chat_id,
-        int from_chat_id, bool disable_notification, int message_id)
+telebot_error_e telebot_forward_message(telebot_handler_t handle, long long int chat_id,
+        long long int from_chat_id, bool disable_notification, int message_id)
 {
     telebot_hdata_t * _handle = (telebot_hdata_t *)handle;
     if (_handle == NULL)
@@ -445,7 +445,7 @@ telebot_error_e telebot_forward_message(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_photo(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_photo(telebot_handler_t handle, long long int chat_id,
         char *photo, bool is_file, char *caption, bool disable_notification,
         int reply_to_message_id, char *reply_markup)
 {
@@ -464,7 +464,7 @@ telebot_error_e telebot_send_photo(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_audio(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_audio(telebot_handler_t handle, long long int chat_id,
         char *audio, bool is_file, int duration, char *performer, char *title,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
@@ -484,7 +484,7 @@ telebot_error_e telebot_send_audio(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_document(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_document(telebot_handler_t handle, long long int chat_id,
         char *document, bool is_file, bool disable_notification,
         int reply_to_message_id, char *reply_markup)
 {
@@ -503,7 +503,7 @@ telebot_error_e telebot_send_document(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_video(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_video(telebot_handler_t handle, long long int chat_id,
         char *video, bool is_file, int duration, int width, int height,
         char *caption, bool disable_notification, int reply_to_message_id,
         char *reply_markup)
@@ -524,7 +524,7 @@ telebot_error_e telebot_send_video(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_voice(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_voice(telebot_handler_t handle, long long int chat_id,
         char *voice, bool is_file, char *caption, int duration,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
@@ -543,7 +543,7 @@ telebot_error_e telebot_send_voice(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_video_note(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_video_note(telebot_handler_t handle, long long int chat_id,
         char *video_note, bool is_file, int duration, int length,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
@@ -563,7 +563,7 @@ telebot_error_e telebot_send_video_note(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_location(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_location(telebot_handler_t handle, long long int chat_id,
         float latitude, float longitude, bool disable_notification,
         int reply_to_message_id, char *reply_markup)
 {
@@ -582,7 +582,7 @@ telebot_error_e telebot_send_location(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_contact(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_contact(telebot_handler_t handle, long long int chat_id,
         char *phone_number, char *first_name, char *last_name,
         bool disable_notification, int reply_to_message_id, char *reply_markup)
 {
@@ -602,7 +602,7 @@ telebot_error_e telebot_send_contact(telebot_handler_t handle, int chat_id,
     return ret;
 }
 
-telebot_error_e telebot_send_chat_action(telebot_handler_t handle, int chat_id,
+telebot_error_e telebot_send_chat_action(telebot_handler_t handle, long long int chat_id,
         char *action)
 {
     telebot_hdata_t * _handle = (telebot_hdata_t *)handle;
@@ -736,7 +736,7 @@ telebot_error_e telebot_download_file(telebot_handler_t handle, char *file_id,
 }
 
 #if 0
-telebot_error_e telebot_delete_message(int chat_id, int message_id)
+telebot_error_e telebot_delete_message(long long int chat_id, int message_id)
 {
     if (g_handler == NULL)
         return TELEBOT_ERROR_NOT_SUPPORTED;
@@ -750,7 +750,7 @@ telebot_error_e telebot_delete_message(int chat_id, int message_id)
     return ret;
 }
 
-telebot_error_e telebot_send_sticker(int chat_id, char *sticker,
+telebot_error_e telebot_send_sticker(long long int chat_id, char *sticker,
         bool is_file, int reply_to_message_id, char *reply_markup)
 {
     if (g_handler == NULL)


### PR DESCRIPTION
There have been two issues with the code concerning group chat IDs.
 - Chat IDs may be up to 56bit long but most variables holding chat IDs were 32bit integers
 - Telegram group chat IDs may be negative. In the telebot library there were many checks to prevent sending to chats with negative ID and throwing an invalid argument error.