### PR TITLE
Correctly initialize curl_h

### DIFF
--- a/src/telebot-core.c
+++ b/src/telebot-core.c
@@ -1572,7 +1572,7 @@ telebot_error_e telebot_core_download_file(telebot_core_handler_t *core_h,
         (out_file == NULL))
         return TELEBOT_ERROR_INVALID_PARAMETER;
 
-    CURL *curl_h;
+    CURL *curl_h = NULL; 
     CURLcode res;
     long resp_code = 0L;
 


### PR DESCRIPTION
Gday, 

It looks like you missed an initialization of curl_h in one of your functions.  Easy mistake and likely has no side effects, but it now allows it to build with -Wall in my environment.

Thank you.