### PR TITLE
Memory leak in telebot_get_updates()

### DIFF
--- a/src/telebot.c
+++ b/src/telebot.c
@@ -153,7 +153,7 @@ telebot_error_e telebot_get_updates(telebot_handler_t handle, int offset,
     struct json_object *array = NULL;
     if (allowed_updates_count > 0)
     {
-        struct json_object *array = json_object_new_array();
+        array = json_object_new_array();
         for (int i = 0; i < allowed_updates_count; i++) {
             const char *item = telebot_update_type_str[allowed_updates[i]];
             json_object_array_add(array, json_object_new_string(item));


### PR DESCRIPTION
Defining another one internal variable "struct json_object *array" in curly braces makes next call "json_object_put(array)" meaningless, do not free LOST pointer to "array" and cause memory leak.