### PR TITLE
Fix hang

### DIFF
--- a/src/telebot-core.c
+++ b/src/telebot-core.c
@@ -295,6 +295,7 @@ telebot_core_curl_perform(telebot_core_handler_t core_h, const char *method, tel
     curl_easy_setopt(curl_h, CURLOPT_URL, URL);
     curl_easy_setopt(curl_h, CURLOPT_WRITEFUNCTION, write_data_cb);
     curl_easy_setopt(curl_h, CURLOPT_WRITEDATA, resp);
+    curl_easy_setopt(curl_h, CURLOPT_TIMEOUT, 10);
 
     if (core_h->proxy_addr != NULL)
     {


### PR DESCRIPTION
Sometime telebot hangs in a curl perform call.
It seems that some failure in connection/communication lead to an infinite wait. add curl option to activate a timeout